### PR TITLE
Fixed minor typo/error relating to birthrate slope calculatations

### DIFF
--- a/Historical MP Series/common/defines/00_defines.txt
+++ b/Historical MP Series/common/defines/00_defines.txt
@@ -1208,7 +1208,7 @@ NPops = {
 @mortality_starving_slope = @[(rate_at_equilibrium-max_mortality)/pop_growth_equilibrium_sol]
 
 ## Birthrate from 0 to pop_growth_transition_sol
-@birthrate_pretransition_slope = @[(birthrate_at_transition-rate_at_equilibrium)/pop_growth_transition_sol]
+@birthrate_pretransition_slope = @[(birthrate_at_transition-max_birthrate)/pop_growth_transition_sol]
 
 ## Mortality from pop_growth_equilibrium_sol to pop_growth_max_sol
 @birthrate_at_growth_max = @[(pop_growth_max_sol-pop_growth_transition_sol)*((min_birthrate-birthrate_at_transition)/(pop_growth_stable_sol-pop_growth_transition_sol))+birthrate_at_transition]


### PR DESCRIPTION
There is a typo in the vanilla defines (which HMPS uses) relating to how the `birthrate_pretransition_slop` is calculated which results in a discontinuity at SOL 10.

Specifically it uses `@birthrate_pretransition_slope = @[(birthrate_at_transition-rate_at_equilibrium)/pop_growth_transition_sol]` when it should use `@birthrate_pretransition_slope = @[(birthrate_at_transition-max_birthrate)/pop_growth_transition_sol]`.
This is a typo doesn't actually result in any difference unless the `transition_birthrate_mult` is set to a value other than `1`. This is why the typo has no effect for vanilla but does have an effect in HMPS because HMPS uses a value of `0.95`.

This ultimately results in a very small discontinuity at SOL 10, (technically SOL is discrete so the idea of discontinuity doesn't really apply but regardless I'm confident that this is not intentional).

(made a post in hmps-feedback on Discord as well)