### PR TITLE
Command and coop eco changes

### DIFF
--- a/Historical MP Series/common/laws/00_economic_system.txt
+++ b/Historical MP Series/common/laws/00_economic_system.txt
@@ -476,6 +476,7 @@ law_command_economy = {
 		country_leverage_resistance_mult = 0.25
 
 		country_disable_privatization_bool = yes
+		country_forbid_monopoly_bool = yes
 	}
 	
 	ai_will_do = {

--- a/Historical MP Series/common/laws/00_economic_system.txt
+++ b/Historical MP Series/common/laws/00_economic_system.txt
@@ -416,7 +416,7 @@ law_command_economy = {
 	disallowing_laws = {
 		law_serfdom
 		law_anarchy
-		law_independent_executive
+		#law_independent_executive
 		law_dual_executive
 		law_parliamentary_system
 	}
@@ -426,7 +426,10 @@ law_command_economy = {
 	}
 	
 	unlocking_laws = {
-		law_vanguardism
+		#law_vanguardism
+		law_autocracy
+		law_oligarchy
+		law_single_party_state
 	}	
 	
 	on_activate = {

--- a/Historical MP Series/common/laws/00_economic_system.txt
+++ b/Historical MP Series/common/laws/00_economic_system.txt
@@ -382,7 +382,8 @@ law_cooperative_ownership = {
 		building_group_bg_arts_allowed_collectivization_add = 1.0
 		
 		country_foreign_collectivization_bool = yes
-		country_disable_privatization_bool = yes
+		#country_disable_privatization_bool = yes
+		country_force_privatization_bool = yes
 		#country_company_pay_to_establish_bool = yes #depricated modifier
 	}
 	


### PR DESCRIPTION
Command Eco can now be pass while having either Vanguardism, Corporatism, Oligarchy, or Autocracy
Command Eco removes monopolies when enacted because that prevents nationalizing buildings not owned by companies that are monopolized
Updated Coop Ownership to 1.9 -- allows companies and workforce to privatize buildings